### PR TITLE
Frame CP update to support Frame App 7.x

### DIFF
--- a/CP_Source/Apps/Frame/build/FrameApp-Preferences-Override.json
+++ b/CP_Source/Apps/Frame/build/FrameApp-Preferences-Override.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://console.nutanix.com",
+  "holdEscTime": 5,
+  "checkForUpdate": true,
+  "clearCache": true,
+  "usb": false,
+  "sendErrorReports": true,
+  "camera": false,
+  "microphone": false
+}

--- a/CP_Source/Apps/Frame/build/build-frame-cp-legacy.sh
+++ b/CP_Source/Apps/Frame/build/build-frame-cp-legacy.sh
@@ -2,16 +2,14 @@
 #set -x
 #trap read debug
 
-# Creating an IGELOS CP for Frame
+# Creating an IGELOS CP for Nutanix Frame
 ## Development machine (Ubuntu 18.04)
 sudo apt install unzip -y
 
 # Obtain latest package and save into Downloads
 # Download Latest Frame App for Linux (Debian)
 # https://portal.nutanix.com/page/downloads?product=xiframe
-framePackage=$(compgen -G "$HOME/Downloads/Frame-*.deb"; compgen -G "$HOME/Downloads/frame_*.deb" | head -n 1)
-
-if [ -z "$framePackage" ]; then
+if ! compgen -G "$HOME/Downloads/Frame-*.deb" > /dev/null; then
   echo "***********"
   echo "Obtain latest .deb package, save into $HOME/Downloads and re-run this script "
   echo "https://portal.nutanix.com/page/downloads?product=xiframe"
@@ -23,7 +21,7 @@ cd build_tar
 
 mkdir -p custom/frame
 
-dpkg -x "$framePackage" custom/frame
+dpkg -x $HOME/Downloads/Frame-*.deb custom/frame
 
 mv custom/frame/usr/share/applications/ custom/frame/usr/share/applications.mime
 
@@ -31,27 +29,28 @@ mv custom/frame/usr/share/applications/ custom/frame/usr/share/applications.mime
 # START: comment out for non-persistency!!!!
 ############################################
 
-mkdir -p custom/frame/userhome/.config/Frame
+mkdir -p custom/frame/userhome/.Nutanix
 
 ##########################################
 # END: comment out for non-persistency!!!!
 ##########################################
 
-wget https://github.com/IGEL-Community/IGEL-Custom-Partitions/raw/master/CP_Packages/Apps/Frame.zip
+wget https://github.com/IGEL-Community/IGEL-Custom-Partitions/raw/master/CP_Packages/Apps/Nutanix_Frame.zip
 
-unzip Frame.zip -d custom
+unzip Nutanix_Frame.zip -d custom
 mkdir -p custom/frame/usr/share/pixmaps
 mv custom/target/build/Frame.png custom/frame/usr/share/pixmaps
 mv custom/target/build/frame-saml2-kiosk-launcher.sh custom/frame
 mv custom/target/build/frame-sat-kiosk-launcher.sh custom/frame
 mv custom/target/build/frame-cp-init-script.sh custom
-mv custom/target/build/FrameApp-Preferences-Override.json custom/frame/userhome/.config/Frame/Preferences.json
+mkdir -p custom/frame/etc/nutanix-frame
+mv custom/target/build/etc_nutanix-frame_preferences.conf custom/frame/etc/nutanix-frame/preferences.conf
 cd custom
 
 # edit inf file for version number
 mkdir getversion
 cd getversion
-ar -x "$framePackage"
+ar -x $HOME/Downloads/Frame-*.deb
 tar xf control.tar.* ./control
 VERSION=$(grep Version control | cut -d " " -f 2)
 #echo "Version is: " ${VERSION}
@@ -62,9 +61,9 @@ sed -i "/^version=/c version=\"${VERSION}\"" target/frame.inf
 
 # new build process into zip file
 tar cvjf target/frame.tar.bz2 frame frame-cp-init-script.sh
-zip -g ../Frame.zip target/frame.tar.bz2 target/frame.inf
-zip -d ../Frame.zip "target/build/*" "target/igel/*" "target/target/*"
-mv ../Frame.zip ../../FrameApp-${VERSION}_igel01.zip
+zip -g ../Nutanix_Frame.zip target/frame.tar.bz2 target/frame.inf
+zip -d ../Nutanix_Frame.zip "target/build/*" "target/igel/*" "target/target/*"
+mv ../Nutanix_Frame.zip ../../Nutanix_Frame-${VERSION}_igel01.zip
 
 cd ../..
 rm -rf build_tar

--- a/CP_Source/Apps/Frame/build/frame-cp-init-script.sh
+++ b/CP_Source/Apps/Frame/build/frame-cp-init-script.sh
@@ -10,8 +10,12 @@ MP=$(get custom_partition.mountpoint)
 # custom partition path
 CP="${MP}/frame"
 
-# config directory
-USER_CONFIG="/userhome/.Nutanix"
+# config directory - check for Legacy Frame App
+if [ -x "/custom/frame/usr/bin/nutanix-frame/Frame" ]; then
+  USER_CONFIG="/userhome/.Nutanix"
+else
+  USER_CONFIG="/userhome/.config/Frame"
+fi
 
 # output to systemlog with ID amd tag
 LOGGER="logger -it ${ACTION}"

--- a/CP_Source/Apps/Frame/igel/frame-app-basic-profile.xml
+++ b/CP_Source/Apps/Frame/igel/frame-app-basic-profile.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <profile>
     <profile_id>31764</profile_id>
-    <profilename>Frame App CP</profilename>
+    <profilename>Frame Basic CP</profilename>
     <firmware>
         <model>IGEL OS 11</model>
-        <version>11.07.170.01</version>
+        <version>11.08.230.01</version>
     </firmware>
-    <description>Frame Custom Partition</description>
+    <description>Frame Basic Custom Partition</description>
     <overwritesessions>false</overwritesessions>
     <is_master_profile>false</is_master_profile>
     <is_igel_os>true</is_igel_os>
@@ -38,12 +38,12 @@
             <ivalue classname="sessions.custom_application%.applaunch_system" variableExpression="" variableSubstitutionActive="false">false</ivalue>
             <ivalue classname="sessions.custom_application%.appliance_mode_access" variableExpression="" variableSubstitutionActive="false">false</ivalue>
             <ivalue classname="sessions.custom_application%.autostart" variableExpression="" variableSubstitutionActive="false">false</ivalue>
-            <ivalue classname="sessions.custom_application%.cmdline" variableExpression="" variableSubstitutionActive="false">/custom/frame/usr/bin/nutanix-frame/Frame –url=console.nutanix.com</ivalue>
+            <ivalue classname="sessions.custom_application%.cmdline" variableExpression="" variableSubstitutionActive="false">/custom/frame/usr/bin/frame</ivalue>
             <ivalue classname="sessions.custom_application%.desktop" variableExpression="" variableSubstitutionActive="false">true</ivalue>
             <ivalue classname="sessions.custom_application%.desktop_path" variableExpression="" variableSubstitutionActive="false"></ivalue>
             <ivalue classname="sessions.custom_application%.hotkey" variableExpression="" variableSubstitutionActive="false"></ivalue>
             <ivalue classname="sessions.custom_application%.hotkeymodifier" variableExpression="" variableSubstitutionActive="false">None</ivalue>
-            <ivalue classname="sessions.custom_application%.icon" variableExpression="" variableSubstitutionActive="false">/custom/frame/usr/share/pixmaps/Frame.png</ivalue>
+            <ivalue classname="sessions.custom_application%.icon" variableExpression="" variableSubstitutionActive="false">/custom/frame/usr/share/icons/hicolor/scalable/apps/frame.svg</ivalue>
             <ivalue classname="sessions.custom_application%.menu_path" variableExpression="" variableSubstitutionActive="false"></ivalue>
             <ivalue classname="sessions.custom_application%.name" variableExpression="" variableSubstitutionActive="false">Frame</ivalue>
             <ivalue classname="sessions.custom_application%.position" variableExpression="" variableSubstitutionActive="false">0</ivalue>

--- a/CP_Source/Apps/Frame/igel/frame-app-v6-basic-profile.xml
+++ b/CP_Source/Apps/Frame/igel/frame-app-v6-basic-profile.xml
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <profile>
     <profile_id>31764</profile_id>
-    <profilename>Frame Version 7 App CP</profilename>
+    <profilename>Frame Basic CP (Legacy)</profilename>
     <firmware>
         <model>IGEL OS 11</model>
         <version>11.08.230.01</version>
     </firmware>
-    <description>Frame 7 Custom Partition</description>
+    <description>Frame Custom Partition</description>
     <overwritesessions>false</overwritesessions>
     <is_master_profile>false</is_master_profile>
     <is_igel_os>true</is_igel_os>
@@ -38,12 +38,12 @@
             <ivalue classname="sessions.custom_application%.applaunch_system" variableExpression="" variableSubstitutionActive="false">false</ivalue>
             <ivalue classname="sessions.custom_application%.appliance_mode_access" variableExpression="" variableSubstitutionActive="false">false</ivalue>
             <ivalue classname="sessions.custom_application%.autostart" variableExpression="" variableSubstitutionActive="false">false</ivalue>
-            <ivalue classname="sessions.custom_application%.cmdline" variableExpression="" variableSubstitutionActive="false">/custom/frame/usr/bin/frame –url=console.nutanix.com</ivalue>
+            <ivalue classname="sessions.custom_application%.cmdline" variableExpression="" variableSubstitutionActive="false">/custom/frame/usr/bin/nutanix-frame/Frame</ivalue>
             <ivalue classname="sessions.custom_application%.desktop" variableExpression="" variableSubstitutionActive="false">true</ivalue>
             <ivalue classname="sessions.custom_application%.desktop_path" variableExpression="" variableSubstitutionActive="false"></ivalue>
             <ivalue classname="sessions.custom_application%.hotkey" variableExpression="" variableSubstitutionActive="false"></ivalue>
             <ivalue classname="sessions.custom_application%.hotkeymodifier" variableExpression="" variableSubstitutionActive="false">None</ivalue>
-            <ivalue classname="sessions.custom_application%.icon" variableExpression="" variableSubstitutionActive="false">/custom/frame/usr/share/icons/hicolor/scalable/apps/frame.svg</ivalue>
+            <ivalue classname="sessions.custom_application%.icon" variableExpression="" variableSubstitutionActive="false">/custom/frame/usr/share/pixmaps/Frame.png</ivalue>
             <ivalue classname="sessions.custom_application%.menu_path" variableExpression="" variableSubstitutionActive="false"></ivalue>
             <ivalue classname="sessions.custom_application%.name" variableExpression="" variableSubstitutionActive="false">Frame</ivalue>
             <ivalue classname="sessions.custom_application%.position" variableExpression="" variableSubstitutionActive="false">0</ivalue>

--- a/CP_Source/Apps/Frame/igel/frame-saml2-kiosk-profile.xml
+++ b/CP_Source/Apps/Frame/igel/frame-saml2-kiosk-profile.xml
@@ -4,7 +4,7 @@
     <profilename>Frame SAML2 Kiosk CP</profilename>
     <firmware>
         <model>IGEL OS 11</model>
-        <version>11.07.170.01</version>
+        <version>11.08.230.01</version>
     </firmware>
     <description>Frame Custom Partition that is specifically configured to use SAML2 IdP for auth, Frame App for a kiosk UX, required environmental variables, and a script to tie it all together.</description>
     <overwritesessions>false</overwritesessions>

--- a/CP_Source/Apps/Frame/igel/frame-sat-kiosk-profile.xml
+++ b/CP_Source/Apps/Frame/igel/frame-sat-kiosk-profile.xml
@@ -4,7 +4,7 @@
     <profilename>Frame SAT Kiosk CP</profilename>
     <firmware>
         <model>IGEL OS 11</model>
-        <version>11.07.170.01</version>
+        <version>11.08.230.01</version>
     </firmware>
     <description>Frame Custom Partition that is specifically configured to use Frame SAT for auth, Frame App for a kiosk UX, required environmental variables, and a script to tie it all together.</description>
     <overwritesessions>false</overwritesessions>
@@ -75,7 +75,7 @@
             <ivalue classname="sessions.custom_application%.restart" variableExpression="" variableSubstitutionActive="false">true</ivalue>
             <ivalue classname="sessions.custom_application%.scardautostart" variableExpression="" variableSubstitutionActive="false">false</ivalue>
             <ivalue classname="sessions.custom_application%.snotify" variableExpression="" variableSubstitutionActive="false">true</ivalue>
-                <ivalue classname="sessions.custom_application%.startmenu" variableExpression="" variableSubstitutionActive="false">true</ivalue>
+            <ivalue classname="sessions.custom_application%.startmenu" variableExpression="" variableSubstitutionActive="false">true</ivalue>
             <ivalue classname="sessions.custom_application%.startmenu_system" variableExpression="" variableSubstitutionActive="false">false</ivalue>
             <ivalue classname="sessions.custom_application%.usehotkey" variableExpression="" variableSubstitutionActive="false">false</ivalue>
             <ivalue classname="sessions.custom_application%.waitfornetwork" variableExpression="" variableSubstitutionActive="false">true</ivalue>


### PR DESCRIPTION
Changes:
- Frame App 6.x now considered "Legacy"
- Support for new Frame App launch params (requiring `--` separator before url params)
- Support Frame App override json preferences for custom building partitions.
- Frame App 6.x can still be built with ` build-frame-cp-legacy.sh`
- Updated kiosk scripts to handle both Frame App 6 & 7 versions and cache.
- Minor updates to UMS Profiles.