### PR TITLE
SAT Kiosk script optimizations.

### DIFF
--- a/CP_Source/Apps/Frame/build/frame-sat-kiosk-launcher.sh
+++ b/CP_Source/Apps/Frame/build/frame-sat-kiosk-launcher.sh
@@ -29,10 +29,11 @@
 # FRAME_LAUNCH_URL - obtained from Dashboard > Launchpad > Advanced Integrations for the Launch Link. The FRAME_LAUNCH_URL could have a Launchpad URL.
 # FRAME_TERMINAL_CONFIG_ID - obtainable from the Launch Link URL.
 # FRAME_LOGOUT_URL - Optional but recommended. Any accessible URL that you'd like your users to be redirected to if they log out for any reason.
+# SESSION_RETRY_DURATION_MINUTES - Optional. Default os 10 minutes. If a session cannot be started within this timeframe, this script will start over and try again.
 #
-# Visit Frame's documentation at https://docs.frame.nutanix.com
+# Visit Frame's documentation at https://docs.fra.me
 
-# Updated Jan 20th, 2023
+# Updated June 21st, 2023
 #
 
 # Check if all the required variables are set correctly
@@ -57,48 +58,50 @@ fi
 
 logMessage() {
     local TODAY=$(date +"%F")
-    echo "[Frame][$(date)]: $1" >> "/userhome/.frame/log-$TODAY.log"
+    echo "[Frame][$(date)]: $1" >>"/userhome/.frame/log-$TODAY.log"
 }
 
 handleWgetStatus() {
     case $1 in
-        1)
-            logMessage "Generic failure to make request."
-            ;;
+    1)
+        logMessage "Generic failure to make request."
+        ;;
 
-        2)
-            logMessage "Error parsing reqeust."
-            ;;
+    2)
+        logMessage "Error parsing reqeust."
+        ;;
 
-        3)
-            logMessage "File I/O error."
-            ;;
+    3)
+        logMessage "File I/O error."
+        ;;
 
-        4)
-            logMessage "Network failure when trying to make a request."
-            ;;
+    4)
+        logMessage "Network failure when trying to make a request."
+        ;;
 
-        5)
-            logMessage "Response: SSL verification failure."
-            ;;
+    5)
+        logMessage "Response: SSL verification failure."
+        ;;
 
-        6)
-            logMessage "Response: Unauthorized."
-            ;;
+    6)
+        logMessage "Response: Unauthorized."
+        ;;
 
-        7)
-            logMessage "Protocol error."
-            ;;
+    7)
+        logMessage "Protocol error."
+        ;;
 
-        8)
-            logMessage "Response: Error from server."
-            ;;
+    8)
+        logMessage "Response: Error from server."
+        ;;
+    *)
+        logMessage "Unexpected status code: $1"
+        ;;
     esac
 }
 
 # Check for another instance is running.
-# pidof -o %PPID -x $0 >/dev/null && logMessage "Process $0 already running." && exit 1
-if [[ `pgrep -f $0` != "$$" ]]; then
+if [[ $(pgrep -f $0) != "$$" ]]; then
     logMessage "Process already running. Exiting."
     exit 1
 fi
@@ -119,7 +122,7 @@ if [ -x "/custom/frame/usr/bin/nutanix-frame/Frame" ]; then
 fi
 
 # Does a passed session state match any of the "open" session states?
-isSessionOpen () {
+isSessionOpen() {
     if printf '%s\0' "${OPEN_SESSION_STATES[@]}" | grep -Fxqz "$1"; then
         sessionStatus=0
     else
@@ -131,12 +134,12 @@ isSessionOpen () {
 # Enable Desktop "autoLaunch" user preference
 setAutoLaunch() {
     local request_body='{"operationName":"SetUserPreferencesMutation","variables":{"__typename":"UserPreferences","desktopAutoLaunch":true,"enableQuickLaunch":false},"query":"mutation SetUserPreferencesMutation($desktopAutoLaunch: Boolean!, $enableQuickLaunch: Boolean!) {\n  setUserPreferences(desktopAutoLaunch: $desktopAutoLaunch, enableQuickLaunch: $enableQuickLaunch) {\n   id\n   preferences {\n     ...PreferencesPanelFragment\n     __typename\n   }\n   __typename\n  }\n}\n\nfragment StorageStatus on StorageStatus {\n  isAttached\n  type\n  __typename\n}\n\nfragment PreferencesPanelFragment on UserPreferences {\n  desktopAutoLaunch\n  enableQuickLaunch\n  __typename\n}\n"}'
-    
+
     # Make request
     local result="$(wget -q -O - $FRAME_GRAPHQL_URL \
         --post-data "$request_body" \
         --header="Authorization: Bearer $token" \
-    --header="Content-Type: application/json")"
+        --header="Content-Type: application/json")"
     handleWgetStatus $?
 }
 
@@ -146,7 +149,7 @@ getSignature() {
     to_sign="$timestamp$FRAME_CLIENT_ID"
     signature=$(echo -n "$to_sign" |
         openssl dgst -sha256 -hmac "$FRAME_CLIENT_SECRET" |
-    sed 's/^.* //')
+        sed 's/^.* //')
 }
 
 getToken() {
@@ -167,7 +170,7 @@ getToken() {
     if [ -n "$FRAME_LOGOUT_URL" ]; then
         metadata=",\"metadata\":{\"should_accept_tos\":false,\"frame_logout_url\":\"$FRAME_LOGOUT_URL\"}"
     else
-    	metadata=",\"metadata\":{\"should_accept_tos\":false}"
+        metadata=",\"metadata\":{\"should_accept_tos\":false}"
     fi
 
     # Include optional params such as first_name, last_name, email_domain, email and/or metadata
@@ -187,7 +190,6 @@ getToken() {
         --header="Content-Type: application/json")"
     handleWgetStatus $?
 
-
     # Remove "" from token
     token=$(echo "$result" | tr -d '"')
 
@@ -204,11 +206,11 @@ queryActiveSession() {
         },
         "query":"query ActiveSessionQuery($terminalConfigurationId: ID!) {\n  activeSession(terminalConfigurationId: $terminalConfigurationId) {\n   id\n   state\n   userId: userUuid\n   __typename\n  }\n}\n"
     }'
-    
+
     activeSessionResponse="$(wget -q -O - $FRAME_GRAPHQL_URL \
         --post-data "$request_body" \
         --header="Authorization: Bearer $token" \
-    --header="Content-Type: application/json")"
+        --header="Content-Type: application/json")"
     handleWgetStatus $?
 
 }
@@ -218,9 +220,9 @@ pollSessionId() {
     logMessage "Checking for active session... $FRAME_SESSION_ID"
 
     local elapsedSeconds=0
-    local retryDurationMinutes=${RETRY_DURATION:-10}       # retry for 10 minutes by default
-    local maxElapsedSeconds=$((retryDurationMinutes * 60)) # Convert minutes to seconds
-    
+    local retryDurationMinutes=${SESSION_RETRY_DURATION_MINUTES:-10} # retry for 10 minutes by default
+    local maxElapsedSeconds=$((retryDurationMinutes * 60))           # Convert minutes to seconds
+
     while [ -z "$FRAME_SESSION_ID" ]; do
         logMessage "Checking for active session... $FRAME_SESSION_ID"
         queryActiveSession
@@ -228,7 +230,7 @@ pollSessionId() {
         # {"data":{"activeSession":{"__typename":"Session","id":"gateway-prod.KR5LDopQG8MzV136","state":"RESERVED","userId":"84c661ab-60ab-43e0-b7bd-3fa44d49ce05"}}}
         # Closed example: {"data":{"activeSession":null}}
         local sessionId="$(echo $activeSessionResponse | grep -o '"id":"[^"]*' | grep -o '[^"]*$')"
-        
+
         if [ "$sessionId" != "" ]; then
             logMessage "Session ID is: $sessionId"
             FRAME_SESSION_ID="$sessionId"
@@ -236,7 +238,7 @@ pollSessionId() {
 
         sleep 2
         elapsedSeconds=$((elapsedSeconds + 2)) # Increment the elapsed seconds by the sleep duration
-        
+
         # Check if the elapsed time has reached the maximum allowed based on the retry duration.
         if [ $elapsedSeconds -ge $maxElapsedSeconds ]; then
             logMessage "Session Start Timeout reached. Restarting Frame Wrapper..."
@@ -244,7 +246,7 @@ pollSessionId() {
             quitAndRestartWrapper
             break
         fi
-        
+
         retryCounter=$((retryCounter + 1))
     done
 }
@@ -252,14 +254,14 @@ pollSessionId() {
 # Query Frame for the status of a specific session based on Session ID.
 querySessionStatus() {
     getSignature
-    
+
     # Make request
     sessionStateResponse="$(wget -q -O - $FRAME_API_URL/accounts/$FRAME_ACCOUNT_ID/sessions/$FRAME_SESSION_ID \
         --header="X-Frame-ClientId:$FRAME_CLIENT_ID" \
         --header="X-Frame-Timestamp:$timestamp" \
-    --header="X-Frame-Signature:$signature")"
+        --header="X-Frame-Signature:$signature")"
     handleWgetStatus $?
-    
+
     logMessage "Session State response: $sessionStateResponse"
     sessionState="$(echo $sessionStateResponse | grep -o '"state":"[^"]*' | grep -o '[^"]*$')"
     isSessionOpen $sessionState
@@ -268,19 +270,19 @@ querySessionStatus() {
 # Poll Frame to keep tabs on the session. If the session closes, restart Frame App.
 pollSessionStatus() {
     logMessage "Polling session status..."
-    
+
     # Query the session's status
     querySessionStatus
     logMessage "Sesssion state: [$sessionStatus] $sessionState"
-    
+
     while [ "$sessionStatus" -eq 0 ]; do
         # Make more requests...
         querySessionStatus
         logMessage "Sesssion state: [$sessionStatus] $sessionState"
-        
-        sleep $FRAME_POLLING_INTERVAL_SECONDS;
+
+        sleep $FRAME_POLLING_INTERVAL_SECONDS
     done
-    
+
     # Session closed or otherwise? Time to restart!
     if [ "$sessionStatus" -eq 1 ]; then
         quitAndRestartWrapper
@@ -323,20 +325,20 @@ quitAndRestartWrapper() {
     kill -9 $(ps aux | grep 'Frame' | awk '{print $2}') &
 
     logMessage "Frame Wrapper closed. Re-launching..."
-    sleep 3;
+    sleep 3
 
     # Reuse or get a new token
     if isTokenExpiring "$token" && [ "$keep_token" = true ]; then
         logMessage "Token is about to expire, regenerating..."
-    getToken
+        getToken
     else
         logMessage "Token is still valid for the next 15 minutes. Keeping existing token from failed session attempt."
     fi
-    
+
     # Start a fresh session
     launchFrame
-    sleep 3;
-    
+    sleep 3
+
     # See how things go :)
     monitorSession
 }
@@ -361,12 +363,12 @@ launchFrame() {
 monitorSession() {
     pollSessionId
     logMessage "Done polling session id. $FRAME_SESSION_ID"
-    
+
     if [ -z ${FRAME_SESSION_ID+X} ]; then
         logMessage "Session ID not found..."
     else
         pollSessionStatus
-    fi;
+    fi
 }
 
 ### Begin!
@@ -388,9 +390,9 @@ if [ -z "$token" ]; then
 else
     # Launch Frame App with our new token
     launchFrame
-    
+
     # Give some time for the UI to load...
-    sleep 2;
+    sleep 2
 
     # Monitor session for token and handle re-launching.
     monitorSession

--- a/CP_Source/Apps/Frame/build/frame-sat-kiosk-launcher.sh
+++ b/CP_Source/Apps/Frame/build/frame-sat-kiosk-launcher.sh
@@ -94,9 +94,6 @@ handleWgetStatus() {
     8)
         logMessage "Response: Error from server."
         ;;
-    *)
-        logMessage "Unexpected status code: $1"
-        ;;
     esac
 }
 
@@ -285,8 +282,8 @@ pollSessionStatus() {
 
     # Session closed or otherwise? Time to restart!
     if [ "$sessionStatus" -eq 1 ]; then
-        quitAndRestartWrapper
         keep_token=false
+        quitAndRestartWrapper
     fi
 }
 


### PR DESCRIPTION
### What's new?
`frame-sat-kiosk-launcher.sh`:
- Added retry mechanisms for scenarios where Frame workload VMs are unavailable for a threshold (configurable via `SESSION_RETRY_DURATION_MINUTES` -- default value is 10 minutes).
- Token expiration handling and reuse in error-states to avoid unnecessary token generation.
- Added additional logging.

### Compatibility
- [x] Tested with Frame App 6.x
- [x] Tested with Frame App 7.x